### PR TITLE
Version 1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [1.0.1] / 2025-04-29
 ### Fix
 - Fix `GitHubRepository` and `README`
+- Fix missing `props`.
 
 ## [1.0.0] / 2024-03-27 - 2025-04-29
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.0.1] / 2025-04-29
+### Fix
+- Fix `GitHubRepository` and `README`
+
 ## [1.0.0] / 2024-03-27 - 2025-04-29
 ### Features
 - Rename to `ricaun.RevitVersion.DefineConstants`.
@@ -16,4 +20,5 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Update to use `DevelopmentDependency` in `csproj`.
 
 [vNext]: ../../compare/1.0.0...HEAD
+[1.0.1]: ../../compare/1.0.0...1.0.1
 [1.0.0]: ../../compare/1.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [1.0.1] / 2025-04-29
+### Features
+- Rename to `ricaun.RevitVersion.DefineConstants`.
+- Support version `2015` to `2030` in `SupportedRevitVersion`.
+- Property `RevitVersion` to `DefineConstants` with `REVITXXXX` and `REVITXXXX_OR_GREATER`.
+- Add `RevitVersionMinimal` `PropertyGroup` to set minimal version for `XXX_OR_GREATER`. (Default: `2019`)
+- Update `XXX_OR_GREATER` implementation based on [discussions](https://github.com/Nice3point/RevitTemplates/discussions/43).
+- `Test` project with `CountTests` for version `2017`, `2019`, `2021` and `2025`. (`RevitVersionMinimal` to `2017`) 
+- Change to `AddImplicitDefineConstants` and `DefineConstants`.
+- Update to use `DevelopmentDependency` in `csproj`.
 ### Fix
 - Fix `GitHubRepository` and `README`
 - Fix missing `props`.

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
 	<PropertyGroup>
-		<Version>1.0.1-rc</Version>
+		<Version>1.0.1</Version>
 	</PropertyGroup>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
 	<PropertyGroup>
-		<Version>1.0.0</Version>
+		<Version>1.0.1-rc</Version>
 	</PropertyGroup>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
 	<PropertyGroup>
-		<Version>1.0.1-rc.2</Version>
+		<Version>1.0.1</Version>
 	</PropertyGroup>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
 	<PropertyGroup>
-		<Version>1.0.1</Version>
+		<Version>1.0.1-rc.1</Version>
 	</PropertyGroup>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
 	<PropertyGroup>
-		<Version>1.0.1-rc.1</Version>
+		<Version>1.0.1-rc.2</Version>
 	</PropertyGroup>
 </Project>

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Nuke](https://img.shields.io/badge/Nuke-Build-blue)](https://nuke.build/)
 [![License MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Build](https://github.com/ricaun-io/RevitVersion.DefineConstants/actions/workflows/Build.yml/badge.svg)](https://github.com/ricaun-io/RevitVersion.DefineConstants/actions)
-[![Release](https://img.shields.io/nuget/v/RevitVersion.DefineConstants?logo=nuget&label=release&color=blue)](https://www.nuget.org/packages/ricaun.RevitVersion.DefineConstants)
+[![Release](https://img.shields.io/nuget/v/ricaun.RevitVersion.DefineConstants?logo=nuget&label=release&color=blue)](https://www.nuget.org/packages/ricaun.RevitVersion.DefineConstants)
 
 Convert `RevitVersion` property to `DefineConstants` with version `2019+` with [or-greater-defines](https://github.com/dotnet/designs/blob/main/accepted/2020/or-greater-defines/or-greater-defines.md).
 

--- a/RevitVersion.DefineConstants.Sample/RevitVersion.DefineConstants.Sample.csproj
+++ b/RevitVersion.DefineConstants.Sample/RevitVersion.DefineConstants.Sample.csproj
@@ -12,7 +12,7 @@
   <Import Project="..\RevitVersion.DefineConstants\ricaun.RevitVersion.DefineConstants.targets" Condition="$(Configuration.Contains('Debug'))" />
 
   <ItemGroup>
-    <PackageReference Include="RevitVersion.DefineConstants" Version="*-*" Condition="!$(Configuration.Contains('Debug'))" />
+    <PackageReference Include="ricaun.RevitVersion.DefineConstants" Version="*-*" Condition="!$(Configuration.Contains('Debug'))" />
   </ItemGroup>
 
 </Project>

--- a/RevitVersion.DefineConstants.Tests/RevitVersion.DefineConstants.Tests.csproj
+++ b/RevitVersion.DefineConstants.Tests/RevitVersion.DefineConstants.Tests.csproj
@@ -39,7 +39,7 @@
   <Import Project="..\RevitVersion.DefineConstants\ricaun.RevitVersion.DefineConstants.targets" Condition="$(Configuration.Contains('Debug'))" />
 
   <ItemGroup>
-    <PackageReference Include="RevitVersion.DefineConstants" Version="*-*" Condition="!$(Configuration.Contains('Debug'))" />
+    <PackageReference Include="ricaun.RevitVersion.DefineConstants" Version="*-*" Condition="!$(Configuration.Contains('Debug'))" />
   </ItemGroup>
 
 </Project>

--- a/RevitVersion.DefineConstants/RevitVersion.DefineConstants.csproj
+++ b/RevitVersion.DefineConstants/RevitVersion.DefineConstants.csproj
@@ -46,10 +46,11 @@
   </PropertyGroup>
 
   <PropertyGroup>
+    <GitHubRepository>RevitVersion.DefineConstants</GitHubRepository>
     <GitHubRepositoryOwner>ricaun-io</GitHubRepositoryOwner>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <PackageProjectUrl>https://github.com/$(GitHubRepositoryOwner)/$(PackageId)</PackageProjectUrl>
-    <RepositoryUrl>https://github.com/$(GitHubRepositoryOwner)/$(PackageId)</RepositoryUrl>
+    <PackageProjectUrl>https://github.com/$(GitHubRepositoryOwner)/$(GitHubRepository)</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/$(GitHubRepositoryOwner)/$(GitHubRepository)</RepositoryUrl>
     <RepositoryType>github</RepositoryType>
     <PackageIcon>icon.png</PackageIcon>
     <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/RevitVersion.DefineConstants/RevitVersion.DefineConstants.csproj
+++ b/RevitVersion.DefineConstants/RevitVersion.DefineConstants.csproj
@@ -96,6 +96,8 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <None Include="$(PackageId).props" PackagePath="build" Pack="true" />
+    <None Include="$(PackageId).targets" PackagePath="build" Pack="true" />
     <Compile Remove="**\*" />
   </ItemGroup>
 


### PR DESCRIPTION
### Features
- Rename to `ricaun.RevitVersion.DefineConstants`.
- Support version `2015` to `2030` in `SupportedRevitVersion`.
- Property `RevitVersion` to `DefineConstants` with `REVITXXXX` and `REVITXXXX_OR_GREATER`.
- Add `RevitVersionMinimal` `PropertyGroup` to set minimal version for `XXX_OR_GREATER`. (Default: `2019`)
- Update `XXX_OR_GREATER` implementation based on [discussions](https://github.com/Nice3point/RevitTemplates/discussions/43).
- `Test` project with `CountTests` for version `2017`, `2019`, `2021` and `2025`. (`RevitVersionMinimal` to `2017`) 
- Change to `AddImplicitDefineConstants` and `DefineConstants`.
- Update to use `DevelopmentDependency` in `csproj`.
### Fix
- Fix `GitHubRepository` and `README`
- Fix missing `props`.